### PR TITLE
Fix environment overwriting

### DIFF
--- a/src/Jlapp/SmartSeeder/SeedCommand.php
+++ b/src/Jlapp/SmartSeeder/SeedCommand.php
@@ -56,7 +56,7 @@ class SeedCommand extends Command
 
         $path = database_path(config('smart-seeder.seedDir'));
 
-        $env = $this->option('env');
+        $env = $this->option('env') ?: $this->migrator->getEnv();
 
         $this->migrator->setEnv($env);
 


### PR DESCRIPTION
When we create migrator repository we pass env variable by constuctor, but when we run the command we overwriting current environment by null (if don't set it in console).
